### PR TITLE
feat:Update OpenAPI specification to rename query parameter `include` to `include[]`

### DIFF
--- a/src/libs/OpenAI/openapi.yaml
+++ b/src/libs/OpenAI/openapi.yaml
@@ -1577,7 +1577,7 @@ paths:
           required: true
           schema:
             type: string
-        - name: include
+        - name: 'include[]'
           in: query
           description: "A list of additional fields to include in the response. Currently the only supported value is `step_details.tool_calls[*].file_search.results[*].content` to fetch the file search result content.\n\nSee the [file search tool documentation](/docs/assistants/tools/file-search/customizing-file-search-settings) for more information.\n"
           schema:
@@ -1833,7 +1833,7 @@ paths:
           description: "A cursor for use in pagination. `before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include before=obj_foo in order to fetch the previous page of the list.\n"
           schema:
             type: string
-        - name: include
+        - name: 'include[]'
           in: query
           description: "A list of additional fields to include in the response. Currently the only supported value is `step_details.tool_calls[*].file_search.results[*].content` to fetch the file search result content.\n\nSee the [file search tool documentation](/docs/assistants/tools/file-search/customizing-file-search-settings) for more information.\n"
           schema:
@@ -1885,7 +1885,7 @@ paths:
           required: true
           schema:
             type: string
-        - name: include
+        - name: 'include[]'
           in: query
           description: "A list of additional fields to include in the response. Currently the only supported value is `step_details.tool_calls[*].file_search.results[*].content` to fetch the file search result content.\n\nSee the [file search tool documentation](/docs/assistants/tools/file-search/customizing-file-search-settings) for more information.\n"
           schema:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated API query parameter from `include` to `include[]`, enhancing clarity for users when specifying additional fields in responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->