### PR TITLE
add custom provider cerebras

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ using var api = CustomProviders.Perplexity("API_KEY");
 using var api = CustomProviders.SambaNova("API_KEY");
 using var api = CustomProviders.Mistral("API_KEY");
 using var api = CustomProviders.Codestral("API_KEY");
+using var api = CustomProviders.Cerebras("API_KEY");
 using var api = CustomProviders.Ollama();
 using var api = CustomProviders.LmStudio();
 ```

--- a/src/libs/OpenAI/CustomProviders.cs
+++ b/src/libs/OpenAI/CustomProviders.cs
@@ -75,7 +75,12 @@ public static class CustomProviders
     /// 
     /// </summary>
     public const string LmStudioBaseUrl = "http://localhost:1234/v1";
-    
+
+    /// <summary>
+    /// https://inference-docs.cerebras.ai/openai
+    /// </summary>
+    public const string CerebrasBaseUrl = "https://api.cerebras.ai/v1";
+
     /// <summary>
     /// Creates an API to use for GitHub Models: https://github.com/marketplace/models
     /// </summary>
@@ -209,5 +214,14 @@ public static class CustomProviders
     public static OpenAiApi LmStudio(Uri? baseUri = null)
     {
         return new OpenAiApi(baseUri: baseUri ?? new Uri(LmStudioBaseUrl));
+    }
+
+    /// <summary>
+    /// Create an API to use for Cerebras.
+    /// </summary>
+    /// <returns></returns>
+    public static OpenAiApi Cerebras(string apiKey)
+    {
+        return new OpenAiApi(apiKey, baseUri: new Uri(CerebrasBaseUrl));
     }
 }

--- a/src/tests/OpenAI.IntegrationTests/CustomProvider.cs
+++ b/src/tests/OpenAI.IntegrationTests/CustomProvider.cs
@@ -18,4 +18,5 @@ public enum CustomProvider
     Mistral,
     Codestral,
     Hyperbolic,
+    Cerebras
 }

--- a/src/tests/OpenAI.IntegrationTests/Tests.Helpers.cs
+++ b/src/tests/OpenAI.IntegrationTests/Tests.Helpers.cs
@@ -135,7 +135,14 @@ public partial class Tests
             
             return pair;
         }
-        
+        if (customProvider == CustomProvider.Cerebras)
+        {
+            return (CustomProviders.Cerebras(apiKey:
+                Environment.GetEnvironmentVariable("CEREBRAS_API_KEY") ??
+                throw new AssertInconclusiveException("CEREBRAS_API_KEY environment variable is not found.")),
+                model ?? "llama3.1-70b");
+        }
+
         var apiKey =
             Environment.GetEnvironmentVariable("OPENAI_API_KEY") ??
             throw new AssertInconclusiveException("OPENAI_API_KEY environment variable is not found.");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for the `Cerebras` custom provider, allowing users to initialize an API instance using `CustomProviders.Cerebras("API_KEY")`.
  
- **Documentation**
	- Updated the `README.md` to include the new `Cerebras` provider and clarified error handling for `tryGetXXX` methods.

- **Bug Fixes**
	- Enhanced the `GetAuthorizedChatApi` method to support the `Cerebras` provider while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->