### PR TITLE
feat:Add Python naming specification to OpenAPI schema with x-stainless-naming

### DIFF
--- a/src/libs/tryAGI.OpenAI/openapi.yaml
+++ b/src/libs/tryAGI.OpenAI/openapi.yaml
@@ -10355,6 +10355,10 @@ components:
                   propertyName: type
                 x-stainless-go-variant-constructor:
                   naming: 'chat_completion_{variant}_tool'
+                x-stainless-naming:
+                  python:
+                    model_name: chat_completion_tool_union
+                    param_model_name: chat_completion_tool_union_param
               description: "A list of tools the model may call. You can provide either\n[custom tools](https://platform.openai.com/docs/guides/function-calling#custom-tools) or\n[function tools](https://platform.openai.com/docs/guides/function-calling).\n"
             top_logprobs:
               maximum: 20


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal naming specifications to improve future Python compatibility. No changes to user-facing features or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->