### PR TITLE
feat:Rename enum mcp_tool_call to mcp_call; add output audio buffer events

### DIFF
--- a/src/libs/tryAGI.OpenAI/Generated/tryAGI.OpenAI.Models.RealtimeMCPToolCall.g.cs
+++ b/src/libs/tryAGI.OpenAI/Generated/tryAGI.OpenAI.Models.RealtimeMCPToolCall.g.cs
@@ -55,7 +55,7 @@ namespace tryAGI.OpenAI
         public required string ServerLabel { get; set; }
 
         /// <summary>
-        /// The type of the item. Always `mcp_tool_call`.
+        /// The type of the item. Always `mcp_call`.
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("type")]
         [global::System.Text.Json.Serialization.JsonConverter(typeof(global::tryAGI.OpenAI.JsonConverters.RealtimeMCPToolCallTypeJsonConverter))]
@@ -90,7 +90,7 @@ namespace tryAGI.OpenAI
         /// The label of the MCP server running the tool.
         /// </param>
         /// <param name="type">
-        /// The type of the item. Always `mcp_tool_call`.
+        /// The type of the item. Always `mcp_call`.
         /// </param>
 #if NET7_0_OR_GREATER
         [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]

--- a/src/libs/tryAGI.OpenAI/Generated/tryAGI.OpenAI.Models.RealtimeMCPToolCallType.g.cs
+++ b/src/libs/tryAGI.OpenAI/Generated/tryAGI.OpenAI.Models.RealtimeMCPToolCallType.g.cs
@@ -4,14 +4,14 @@
 namespace tryAGI.OpenAI
 {
     /// <summary>
-    /// The type of the item. Always `mcp_tool_call`.
+    /// The type of the item. Always `mcp_call`.
     /// </summary>
     public enum RealtimeMCPToolCallType
     {
         /// <summary>
         /// 
         /// </summary>
-        McpToolCall,
+        McpCall,
     }
 
     /// <summary>
@@ -26,7 +26,7 @@ namespace tryAGI.OpenAI
         {
             return value switch
             {
-                RealtimeMCPToolCallType.McpToolCall => "mcp_tool_call",
+                RealtimeMCPToolCallType.McpCall => "mcp_call",
                 _ => throw new global::System.ArgumentOutOfRangeException(nameof(value), value, null),
             };
         }
@@ -37,7 +37,7 @@ namespace tryAGI.OpenAI
         {
             return value switch
             {
-                "mcp_tool_call" => RealtimeMCPToolCallType.McpToolCall,
+                "mcp_call" => RealtimeMCPToolCallType.McpCall,
                 _ => null,
             };
         }

--- a/src/libs/tryAGI.OpenAI/openapi.yaml
+++ b/src/libs/tryAGI.OpenAI/openapi.yaml
@@ -22195,9 +22195,9 @@ components:
           description: The label of the MCP server running the tool.
         type:
           enum:
-            - mcp_tool_call
+            - mcp_call
           type: string
-          description: The type of the item. Always `mcp_tool_call`.
+          description: The type of the item. Always `mcp_call`.
           x-stainless-const: true
       description: "A Realtime item representing an invocation of a tool on an MCP server.\n"
     RealtimeMCPToolExecutionError:
@@ -32990,6 +32990,15 @@ x-oaiMeta:
           path: <auto>
           type: object
         - key: RealtimeServerEventInputAudioBufferTimeoutTriggered
+          path: <auto>
+          type: object
+        - key: RealtimeServerEventOutputAudioBufferStarted
+          path: <auto>
+          type: object
+        - key: RealtimeServerEventOutputAudioBufferStopped
+          path: <auto>
+          type: object
+        - key: RealtimeServerEventOutputAudioBufferCleared
           path: <auto>
           type: object
         - key: RealtimeServerEventResponseCreated


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new realtime server events for audio output lifecycle: buffer started, stopped, and cleared, enabling finer-grained audio state tracking.

* **Refactor**
  * Renamed the realtime MCP execution type from “mcp_tool_call” to “mcp_call” and updated its description. This change may require updating client integrations that reference the old value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->